### PR TITLE
Add core-web-vitals history checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
     - 1.2.7. [Pingdom Website Speed Test](#-pingdom-website-speed-test)
     - 1.2.8. [Varvy](#-varvy)
     - 1.2.9. [DebugBear](#-debugbear)
+    - 1.2.10. [Core Web Vitals History Checker](#-core-web-vitals-history-checker)
 
     1.3. [Chrome Extensions](#chrome-extensions)
     - 1.3.1. [React Developer Tools](#-react-developer-tools)
@@ -283,6 +284,12 @@
 > - Real user Core Web Vitals data from Google
 > - Lighthouse report
 ----------
+
+> #### 📈 [Core Web Vitals History Checker](https://punits.dev/core-web-vitals-historical/)
+> Know if the core web vitals for a url or an origin have improved, degraded or remained stable for the last six months.
+----------
+
+Core Web Vitals History Checker
 
 ### Chrome Extensions
 ℹ️ *Chrome extensions can help you enhance your workflow by providing some additional debugging tools on top of Chrome DevTools*


### PR DESCRIPTION
Hey there,
I created a small tool to check the trend of core-web-vitals for last 6 months (based on Google's CrUX data) to identify regressions. If this would be useful to you / users of your list - please accept the PR.